### PR TITLE
Remove `CanvasInfo#canvas`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## [0.3.2] - ????-??-??
+## [0.4.0] - ????-??-??
 
+- Remove `CanvasInfo#canvas`. Use `width` and `height` from `CanvasInfo` instead.
 - Draw boundary box for the demo scenes. To better track the zoom level.
 - Track mouse position in the debug box.
 - Fix canvas clean-up glitch.

--- a/demo/src/animationDemo.ts
+++ b/demo/src/animationDemo.ts
@@ -13,11 +13,10 @@ let y1 = boundary
 let y1Delta = speed
 
 function animationDemo(ci: CanvasInfo) {
-  const { ctx, canvas } = ci
   if (x1 <= boundary) {
     x1Delta = speed
   }
-  if (x1 >= canvas.width - boundary) {
+  if (x1 >= ci.width - boundary) {
     x1Delta = -speed
   }
   x1 += x1Delta
@@ -25,7 +24,7 @@ function animationDemo(ci: CanvasInfo) {
   if (y1 <= boundary) {
     y1Delta = speed
   }
-  if (y1 >= canvas.height - boundary) {
+  if (y1 >= ci.height - boundary) {
     y1Delta = -speed
   }
   y1 += y1Delta
@@ -33,18 +32,18 @@ function animationDemo(ci: CanvasInfo) {
   boundaryBox(ci, boundary)
 
   // draw lines
-  line(ctx, {
+  line(ci.ctx, {
     x1,
     y1,
-    x2: canvas.width - x1,
-    y2: canvas.height - y1,
+    x2: ci.width - x1,
+    y2: ci.height - y1,
     color: 'red',
     width: 2,
   })
-  line(ctx, {
+  line(ci.ctx, {
     x1,
-    y1: canvas.height - y1,
-    x2: canvas.width - x1,
+    y1: ci.height - y1,
+    x2: ci.width - x1,
     y2: boundary,
     color: 'green',
     width: 3,

--- a/demo/src/boundaryBox.ts
+++ b/demo/src/boundaryBox.ts
@@ -1,16 +1,16 @@
 import { rect } from 'Canvas/rect'
 import { CanvasInfo } from 'Canvas/types'
 
-function boundaryBox({ ctx, canvas, zoom }: CanvasInfo, boundary: number) {
-  rect(ctx, {
+function boundaryBox(ci: CanvasInfo, boundary: number) {
+  rect(ci.ctx, {
     x: boundary - 1,
     y: boundary - 1,
-    w: canvas.width - 2 * (boundary - 1),
-    h: canvas.height - 2 * (boundary - 1),
+    w: ci.width - 2 * (boundary - 1),
+    h: ci.height - 2 * (boundary - 1),
     color: 'rgb(24, 188, 254)',
     dashed: true,
     dashGap: 15,
-    lineWidth: 1 * (1 / zoom.level), // ignore zoom level for the box
+    lineWidth: 1 * (1 / ci.zoom.level), // ignore zoom level for the box
   })
 }
 

--- a/demo/src/ellipseDemo.ts
+++ b/demo/src/ellipseDemo.ts
@@ -1,13 +1,13 @@
 import { ellipse } from 'Canvas/index'
 import { CanvasInfo } from 'Canvas/types'
 
-function ellipseDemo({ ctx, canvas: { width, height } }: CanvasInfo) {
+function ellipseDemo(ci: CanvasInfo) {
   for (let r = 1; r < 5; r++) {
-    ellipse(ctx, {
-      x: width / 2,
-      y: height / 2,
-      rx: (width / 2 / 5) * r,
-      ry: (height / 2 / 7) * r,
+    ellipse(ci.ctx, {
+      x: ci.width / 2,
+      y: ci.height / 2,
+      rx: (ci.width / 2 / 5) * r,
+      ry: (ci.height / 2 / 7) * r,
       color: 'orange',
     })
   }

--- a/demo/src/lineDemo.ts
+++ b/demo/src/lineDemo.ts
@@ -6,22 +6,20 @@ import boundaryBox from './boundaryBox'
 const boundary = 10
 
 function lineDemo(ci: CanvasInfo) {
-  const { ctx, canvas } = ci
-
   boundaryBox(ci, boundary)
 
   // draw lines
-  line(ctx, {
+  line(ci.ctx, {
     x1: boundary,
     y1: boundary,
-    x2: canvas.width - boundary,
-    y2: canvas.height - boundary,
+    x2: ci.width - boundary,
+    y2: ci.height - boundary,
     color: 'red',
   })
-  line(ctx, {
+  line(ci.ctx, {
     x1: boundary,
-    y1: canvas.height - boundary,
-    x2: canvas.width - boundary,
+    y1: ci.height - boundary,
+    x2: ci.width - boundary,
     y2: boundary,
     color: 'green',
     dashed: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@devstronomy/canvas",
-  "version": "0.3.2-alpha.1",
+  "version": "0.4.0-alpha.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@devstronomy/canvas",
-      "version": "0.3.2-alpha.1",
+      "version": "0.4.0-alpha.1",
       "license": "MIT",
       "devDependencies": {
         "@devstronomy/dev-dependencies": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devstronomy/canvas",
-  "version": "0.3.2-alpha.1",
+  "version": "0.4.0-alpha.1",
   "description": "Canvas Drawing Library",
   "license": "MIT",
   "author": "Martin Krauskopf <martin.krauskopf@gmail.com> (https://devstronomy.com/)",

--- a/src/canvas.ts
+++ b/src/canvas.ts
@@ -20,9 +20,9 @@ function fill(ctx: CanvasContext, color: string): void {
   ctx.fill()
 }
 
-function fillCanvas({ ctx, canvas }: CanvasInfo, color: string): void {
-  ctx.fillStyle = color
-  ctx.fillRect(0, 0, canvas.width, canvas.height)
+function fillCanvas(ci: CanvasInfo, color: string): void {
+  ci.ctx.fillStyle = color
+  ci.ctx.fillRect(0, 0, ci.width, ci.height)
 }
 
 function fillRGB(ctx: CanvasContext, r: string, g: string, b: string): void {

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -57,7 +57,7 @@ function initializeCanvas(
     // prepare canvas
     fillCanvas(ci, 'black')
     ci.ctx.setTransform(1, 0, 0, 1, 1, 1)
-    ci.ctx.fillRect(0, 0, ci.canvas.width, ci.canvas.height)
+    ci.ctx.fillRect(0, 0, ci.width, ci.height)
     ci.ctx.translate(ci.width / 2, ci.height / 2)
     ci.ctx.scale(ci.zoom.level, ci.zoom.level)
     ci.ctx.translate(-ci.width / 2, -ci.height / 2)
@@ -111,7 +111,6 @@ function initializeCanvas(
   }
 
   let ci: CanvasInfo = {
-    canvas: canvasEl,
     ctx,
     width: 0,
     height: 0,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,6 @@
-type Canvas = HTMLCanvasElement
 type CanvasContext = CanvasRenderingContext2D
 
 type CanvasInfo = {
-  canvas: Canvas
   ctx: CanvasContext
 
   width: number
@@ -36,4 +34,4 @@ type Color = Readonly<{
   b: string
 }>
 
-export type { Canvas, CanvasContext, CanvasInfo, Color, DrawFunction }
+export type { CanvasContext, CanvasInfo, Color, DrawFunction }


### PR DESCRIPTION
Use `width` and `height` from `CanvasInfo` instead. There is no need for current clients to access the canvas element.

Bump up version to 0.4.0, API breaking change.
